### PR TITLE
Refresh theme with playful font and vibrant background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -16,7 +18,13 @@
     
     /* Cores de fundo */
     --background: 210 100% 98%;          /* Azul muito claro */
-    --game-bg-gradient: linear-gradient(135deg, hsl(210 100% 98%), hsl(160 100% 98%), hsl(45 100% 98%));
+    --game-bg-gradient: linear-gradient(
+      130deg,
+      hsl(210 100% 92%),
+      hsl(160 95% 82%),
+      hsl(45 100% 80%),
+      hsl(320 95% 85%)
+    );
     
     /* Cores de texto */
     --foreground: 220 30% 25%;           /* Cinza azulado escuro */
@@ -91,9 +99,17 @@
 
   body {
     @apply text-foreground;
-    background: var(--game-bg-gradient);
     min-height: 100vh;
-    font-family: 'Comic Sans MS', cursive, sans-serif;
+    font-family: 'Baloo 2', 'Fredoka', 'Comic Sans MS', cursive, sans-serif;
+    background-color: hsl(210 100% 95%);
+    background-image:
+      radial-gradient(circle at 12% 18%, hsl(var(--game-accent) / 0.45) 0%, transparent 58%),
+      radial-gradient(circle at 85% 22%, hsl(var(--game-pink) / 0.45) 0%, transparent 55%),
+      radial-gradient(circle at 18% 78%, hsl(var(--game-secondary) / 0.45) 0%, transparent 56%),
+      radial-gradient(circle at 78% 78%, hsl(var(--game-purple) / 0.45) 0%, transparent 55%),
+      var(--game-bg-gradient);
+    background-attachment: fixed;
+    background-size: cover;
   }
 
   /* Animações personalizadas para o jogo */


### PR DESCRIPTION
## Summary
- import and apply the Baloo 2 typeface to give the game a playful, readable feel
- brighten the background gradient and add colorful radial accents to reinforce a child-friendly theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa9965438832f94a23e874acbca3b